### PR TITLE
Update Dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,19 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    open-pull-requests-limit: 10
     directory: "/"
+    groups:
+      all-github-actions:
+        patterns:
+          - "*"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+      time: "08:30"
+      timezone: "Europe/Vienna"
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "bot"
+      - "github-actions"
+    assignees:
+      - "cleot" # devops


### PR DESCRIPTION
Reduced open pull requests limit and updated schedule to weekly on Monday at 08:30.