### PR TITLE
Add MIT licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Bitcredit Protocol
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This repository is **public and has no licence file**. Under default copyright that means all rights reserved: nobody may legally use, copy or modify the code — including other Bitcredit repositories that depend on it, and any outside contributor.

MIT, using the organisation's standard text. The body is byte-identical to the licence in the twenty repositories that already have one; only the copyright line differs.

```
Copyright (c) 2025 Bitcredit Protocol
```

Holder is `Bitcredit Protocol`, the form used in fifteen of the existing files. Year is this repository's creation year.

Four sibling repositories are getting the same change: `wildcat-dashboard-ui`, `docker-external`, `static-assets`, `bcr-load-tests`, `wallet-version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)