### PR TITLE
Cooldown on action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,5 +15,9 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     assignees:
       - "cleot" # devops


### PR DESCRIPTION
Two changes, one commit each.

## Cooldown on the `github-actions` block

Every package block in this organisation has carried a cooldown for months — thirty days on a major, seven on a minor, three on a patch. The `github-actions` block never had one, which is backwards: an action runs inside the job, with the job's token and secrets, while an npm package usually just sits in `node_modules`.

A compromised release is normally pulled within days. Three days on a patch is the difference between adopting one and reading about it.

## Verification

Both files parse, and the diffs were checked line by line before pushing: the config diff contains only `cooldown` and group lines, the workflow diff only `uses:` lines. Across the organisation this pins 39 references and leaves no moving tag behind.
